### PR TITLE
Update css-focus-visible.json

### DIFF
--- a/features-json/css-focus-visible.json
+++ b/features-json/css-focus-visible.json
@@ -9,20 +9,28 @@
       "title":"Prototype for `:focus-visible`"
     },
     {
+      "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=817199",
+      "title":"Chrome does not support CSS Selectors 4 :focus-visible"
+    },
+    {
+      "url":"https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/-wN72ESFsyo",
+      "title":"Blink: Intent to implement :focus-visible pseudo class."
+    },
+    {
+      "url":"https://bugzilla.mozilla.org/show_bug.cgi?id=1437901&GoAheadAndLogIn=1",
+      "title":"Bugzilla: Add :focus-visible (former :focus-ring)"
+    },
+    {
       "url":"https://bugs.webkit.org/show_bug.cgi?id=30523",
       "title":"WebKit bug #140144: Add support for `-webkit-focusring` CSS pseudo class"
     },
     {
-      "url":"https://bugs.chromium.org/p/chromium/issues/detail?id=271023",
-      "title":"Chromium issue #271023: Outline should not appear on elements focused by mouse"
+      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/19594159--focus-visible",
+      "title":"Microsoft Edge implementation suggestion"
     },
     {
       "url":"https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-focusring",
       "title":"Mozilla Developer Network (MDN) documentation - :-moz-focusring"
-    },
-    {
-      "url":"https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/19594159--focus-visible",
-      "title":"Microsoft Edge implementation suggestion"
     }
   ],
   "bugs":[


### PR DESCRIPTION
Hey @fyrd!

Here's a bit of an update for :focus-visible.

One thing I was wondering: We currently have an implementation of :focus-visible behind the experimental web platform features flag in Chrome 67. Does caniuse track features that are behind a flag?